### PR TITLE
Moved .header-wrapper forward

### DIFF
--- a/assets/css/compiled-style.css
+++ b/assets/css/compiled-style.css
@@ -206,6 +206,7 @@ footer {
   margin-top: 15px;
   position: sticky;
   height: 30px;
+  z-index: 2;
 }
 
 header {

--- a/component-updates.html
+++ b/component-updates.html
@@ -81,7 +81,7 @@
         breakpoint, functionality reverts to display just the icon, as there is less space.</p>
       <div class="media-frame">
         <div class="responsive-embed">
-          <iframe width="420" height="315" src="https://www.youtube.com/embed/mEPan-ueJ38" frameborder="0"
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/mEPan-ueJ38" frameborder="0"
             allowfullscreen></iframe>
         </div>
       </div>
@@ -93,7 +93,7 @@
         looked at </p>
       <div class="media-frame">
         <div class="responsive-embed">
-          <iframe width="420" height="315" src="https://www.youtube.com/embed/DddfFJn0hIg" frameborder="0"
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/DddfFJn0hIg" frameborder="0"
             allowfullscreen></iframe>
         </div>
       </div>
@@ -107,7 +107,7 @@
           so they are within the embed frame.</a></p>
       <div class="media-frame">
         <div class="responsive-embed">
-          <iframe width="420" height="315" src="https://www.youtube.com/embed/Y0CIeQ9UEXM" frameborder="0"
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/Y0CIeQ9UEXM" frameborder="0"
             allowfullscreen></iframe>
         </div>
       </div>


### PR DESCRIPTION
Header was appearing behind responsive media, so I've given it a z-index so that it sits on top.